### PR TITLE
feat: :sparkles: Add ability to select start and end points for search

### DIFF
--- a/frontend/src/components/StartAndEndPointsButton.tsx
+++ b/frontend/src/components/StartAndEndPointsButton.tsx
@@ -1,0 +1,15 @@
+import { signal } from "@preact/signals-react";
+
+export const selectionModeSignal = signal<boolean>(false);
+
+const StartAndEndPointsButton = () => {
+  const toggleSelectionMode = () => {
+    selectionModeSignal.value = !selectionModeSignal.value;
+  };
+
+  return (
+    <button onClick={toggleSelectionMode}>Set start and end points</button>
+  );
+};
+
+export default StartAndEndPointsButton;

--- a/frontend/src/components/Tile.tsx
+++ b/frontend/src/components/Tile.tsx
@@ -5,6 +5,8 @@ type TileProps = {
   onTileEnter: () => void;
   onTileClick: () => void;
   onMouseDown: () => void;
+  isStartPoint: boolean;
+  isEndPoint: boolean;
 };
 const Tile = ({
   width,
@@ -13,12 +15,18 @@ const Tile = ({
   onTileEnter,
   onTileClick,
   onMouseDown,
+  isStartPoint,
+  isEndPoint,
 }: TileProps) => {
+  let backgroundColor = isActive ? "black" : "white";
+  if (isStartPoint) backgroundColor = "green";
+  if (isEndPoint) backgroundColor = "red";
+
   const tileStyle = {
     width: `${width}vw`,
     height: `${height}vh`,
     border: "0.5px solid",
-    backgroundColor: isActive ? "black" : "white",
+    backgroundColor: backgroundColor,
   };
 
   return (

--- a/frontend/src/components/mapGrid/MapGrid.tsx
+++ b/frontend/src/components/mapGrid/MapGrid.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { sliderSignal } from "../../pages/HomePage.tsx";
 import Tile from "../Tile.tsx";
 import "./MapGrid.css";

--- a/frontend/src/components/mapGrid/MapGrid.tsx
+++ b/frontend/src/components/mapGrid/MapGrid.tsx
@@ -1,14 +1,19 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { sliderSignal } from "../../pages/HomePage.tsx";
 import Tile from "../Tile.tsx";
 import "./MapGrid.css";
+import { selectionModeSignal } from "../StartAndEndPointsButton.tsx";
 
 const MapGrid = () => {
-  const size = sliderSignal.value;
-  const height = Math.round(size * (9 / 16));
-  const tileWidth = 80 / size;
-  const tileHeight = 80 / height;
+  const size = sliderSignal.value; // Get the current size of the grid
+  const height = Math.round(size * (9 / 16)); // Set aspect ratio of grid to 16:9
+  const tileWidth = 80 / size; // 80 is the width of the grid container
+  const tileHeight = 80 / height; // 80 is the height of the grid container
+
+  // State to track the start and end point
+  const [startPoint, setStartPoint] = useState<string | null>(null);
+  const [endPoint, setEndPoint] = useState<string | null>(null);
 
   // Create a state to track the active state of each tile
   const [activeTiles, setActiveTiles] = useState(() => {
@@ -26,17 +31,16 @@ const MapGrid = () => {
     null
   );
 
-  // Modify mouse down handler to set initial drag state
+  // Handle dragging the mouse to toggle tiles
   const handleMouseDown = (row: number, col: number) => {
     setIsMouseDown(true);
     setInitialDragState(activeTiles[`${row}-${col}`]);
   };
 
-  // Update the tile enter function
+  // Handle dragging the mouse to toggle tiles
   const handleTileEnter = useCallback(
     (row: number, col: number) => {
       if (isMouseDown) {
-        // Check against the initial drag state
         setActiveTiles((prev) => ({
           ...prev,
           [`${row}-${col}`]: initialDragState ? false : true,
@@ -46,14 +50,24 @@ const MapGrid = () => {
     [isMouseDown, initialDragState]
   );
 
+  // Handle clicking a tile to toggle it
   const handleTileClick = (row: number, col: number) => {
-    // Toggles the tile regardless of the mouse down state
-    setActiveTiles((prev) => ({
-      ...prev,
-      [`${row}-${col}`]: !prev[`${row}-${col}`],
-    }));
+    if (selectionModeSignal.value) {
+      if (!startPoint) {
+        setStartPoint(`${row}-${col}`);
+      } else if (!endPoint) {
+        setEndPoint(`${row}-${col}`);
+        selectionModeSignal.value = false;
+      } else {
+        setActiveTiles((prev) => ({
+          ...prev,
+          [`${row}-${col}`]: !prev[`${row}-${col}`],
+        }));
+      }
+    }
   };
 
+  // Render the grid of tiles
   const renderGrid = () => {
     const grid = [];
     for (let row = 0; row < height; row++) {
@@ -68,6 +82,8 @@ const MapGrid = () => {
             onTileEnter={() => handleTileEnter(row, col)}
             onTileClick={() => handleTileClick(row, col)}
             onMouseDown={() => handleMouseDown(row, col)}
+            isStartPoint={startPoint === `${row}-${col}`}
+            isEndPoint={endPoint === `${row}-${col}`}
           />
         );
       }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { signal } from "@preact/signals-react";
 import MapGrid from "../components/mapGrid/MapGrid";
 import MapSizeSlider from "../components/MapSizeSlider";
+import StartAndEndPointsButton from "../components/StartAndEndPointsButton";
 
 export const sliderSignal = signal<number>(50);
 
@@ -10,8 +11,9 @@ const HomePage = () => {
       <div style={{ height: "fit-content" }}>
         <MapGrid />
       </div>
-      <div className="h-5 mt-5">
+      <div className="flex h-5 mt-5">
         <MapSizeSlider />
+        <StartAndEndPointsButton />
       </div>
     </div>
   );


### PR DESCRIPTION
@Jensern1 Made new component "StartAndEndPointsButton" displayed on the HomePage. Upon click, user can select two tiles: a start point, which turns green, and an end point, which turns red. The start and end points are stored in two states in the MapGrid-component.

#2